### PR TITLE
Correção do erro do DotEnv

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-const express = require('express');
 const dotenv = require('dotenv');
+dotenv.config();
+const express = require('express');
 const authController = require('./authController');
 
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
Correção do DotEnv que não estava deixando o servidor ser iniciado pelo comando:
node src/index.js

